### PR TITLE
Fix for Safari - swipe up for fullscreen

### DIFF
--- a/src/touch.js
+++ b/src/touch.js
@@ -203,7 +203,7 @@ var touchEvents = {
         var t = inEvent.changedTouches[0];
 
         // check the intended scroll axis, and other axis
-        var a = scrollAxis;
+        var a = scrollAxis === 'Y' ? 'X' : 'Y';
         var oa = scrollAxis === 'Y' ? 'X' : 'Y';
         var da = Math.abs(t['client' + a] - this.firstXY[a]);
         var doa = Math.abs(t['client' + oa] - this.firstXY[oa]);


### PR DESCRIPTION
Issue: Safari - swipe up for fullscreen in portrait mode. shouldScroll always returned false and as a result a preventDefault would fire, preventing the browser default events from happening (like swipe up for fullscreen)


